### PR TITLE
fix:GetJsAPIConfig的NonceStr重新生成导致签名验证失败

### DIFF
--- a/mch/pay/jssdk_wxpay.go
+++ b/mch/pay/jssdk_wxpay.go
@@ -83,7 +83,7 @@ func (c *Pay) GetJsAPIConfig(order OrderInput) (config *WxPayInfo, err error) {
 	result["paySign"] = sign
 
 	config = new(WxPayInfo)
-	config.NonceStr = util.RandomStr(8)
+	config.NonceStr = nocestr
 	config.TimeStamp = fmt.Sprint(time.Now().Unix())
 	config.AppID = c.AppID
 	config.Package = "prepay_id=" + prepayID


### PR DESCRIPTION
fix #4